### PR TITLE
Refactor repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Process CPC XML files from a directory containing the classification scheme:
 
 ```bash
 # Using UV
-uv run python cpc_tree.py /path/to/xml/directory
+uv run python -m cpc_tree /path/to/xml/directory
 
 # Using Python directly
-python cpc_tree.py /path/to/xml/directory
+python -m cpc_tree /path/to/xml/directory
 ```
 
 This will generate a `cpc_tree.json` file containing the complete CPC hierarchy.
@@ -219,8 +219,11 @@ uv run pre-commit run --all-files
 
 ```
 cpc-tree/
-├── cpc_tree.py          # Main processing logic
-├── test_cpc_tree.py     # Test suite
+├── cpc_tree/            # Package containing logic and CLI
+│   ├── __init__.py      # Core processing logic
+│   └── __main__.py      # Command line entry point
+├── tests/
+│   └── test_cpc_tree.py # Test suite
 ├── cpc_tree.json        # Generated CPC hierarchy (large file)
 ├── pyproject.toml       # Project configuration
 ├── uv.lock             # Locked dependencies

--- a/cpc_tree/__init__.py
+++ b/cpc_tree/__init__.py
@@ -1,6 +1,4 @@
-import argparse
 import logging
-import json
 import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -110,17 +108,3 @@ def build_cpc_tree(directory: str) -> Dict[str, Any]:
             cpc_tree[symbol] = parse_item(top_level_item, directory)
 
     return cpc_tree
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Build the CPC tree from XML files.")
-    parser.add_argument(
-        "xml_directory",
-        type=str,
-        help="Path to the directory containing CPC XML files (should include cpc-scheme.xml)",
-    )
-    args = parser.parse_args()
-    xml_dir: str = args.xml_directory
-    cpc_tree: Dict[str, Any] = build_cpc_tree(xml_dir)
-    with open("cpc_tree.json", "w+") as f:
-        json.dump(cpc_tree, f, indent=4)

--- a/cpc_tree/__main__.py
+++ b/cpc_tree/__main__.py
@@ -1,0 +1,23 @@
+import argparse
+import json
+from typing import Any, Dict
+
+from . import build_cpc_tree
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build the CPC tree from XML files.")
+    parser.add_argument(
+        "xml_directory",
+        type=str,
+        help="Path to the directory containing CPC XML files (should include cpc-scheme.xml)",
+    )
+    args = parser.parse_args()
+    xml_dir: str = args.xml_directory
+    cpc_tree: Dict[str, Any] = build_cpc_tree(xml_dir)
+    with open("cpc_tree.json", "w+", encoding="utf-8") as f:
+        json.dump(cpc_tree, f, indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cpc_tree.py
+++ b/tests/test_cpc_tree.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from cpc_tree import build_cpc_tree, load_cpc_tree
 
 


### PR DESCRIPTION
## Summary
- move library code into `cpc_tree` package and expose CLI via `python -m cpc_tree`
- relocate tests into `tests/` package and update README

## Testing
- `uv run pre-commit run --files cpc_tree/__init__.py cpc_tree/__main__.py tests/test_cpc_tree.py README.md`
- `uv run pytest` *(fails: [Errno 2] No such file or directory: 'CPCSchemeXML202508/cpc-scheme.xml')*

------
https://chatgpt.com/codex/tasks/task_e_6893df8fed94832693a32f0777d70121